### PR TITLE
fix import error in cypress

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
-import { waitForStableDOM } from './wait-for-stable-dom'
+const { waitForStableDOM } = require('./wait-for-stable-dom')
 
-export const registerCommand = () => {
+const registerCommand = () => {
   Cypress.Commands.add(
     'waitForStableDOM',
     { prevSubject: 'optional' },
     waitForStableDOM
   )
 }
+
+module.exports = { registerCommand }

--- a/src/wait-for-stable-dom.js
+++ b/src/wait-for-stable-dom.js
@@ -11,7 +11,7 @@ const defaultOptions = {
   },
 };
 
-export const waitForStableDOM = (subject, userOptions, iteration = 0) => {
+const waitForStableDOM = (subject, userOptions, iteration = 0) => {
   const options = Object.assign({}, defaultOptions, userOptions);
   
   cy.document()
@@ -35,3 +35,5 @@ export const waitForStableDOM = (subject, userOptions, iteration = 0) => {
       });
     });
 }
+
+module.exports = { waitForStableDOM };


### PR DESCRIPTION
Hi, 

I found the problem that the npm package could not be used from cypress.

When I imported it as described in the README, the following error occurred:
```
SyntaxError: 'import' and 'export' may appear only with 'sourceType: module'
    at EventEmitter.handler (/workspace/.cache/9.4.1/Cypress/resources/app/packages/server/lib/plugins/util.js:69:27)
    at EventEmitter.emit (node:events:394:28)
    at ChildProcess.<anonymous> (/workspace/.cache/9.4.1/Cypress/resources/app/packages/server/lib/plugins/util.js:19:22)
    at ChildProcess.emit (node:events:394:28)
    at emit (node:internal/child_process:920:12)
    at processTicksAndRejections (node:internal/process/task_queues:84:21)
```
We can avoid this error by adding the settings as described [here](https://github.com/cypress-io/cypress-browserify-preprocessor/issues/19#issuecomment-434460422), but since this is a module for cypress, it's better to be able to use it without such additional settings.

This PR fixes the issue describe above.