### PR TITLE
Add export definition for module

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,3 +18,7 @@ declare namespace Cypress {
     waitForStableDOM(commandOptions, mutationOptions): Chainable<JQuery<HTMLElement>>
   }
 }
+
+declare module "cypress-wait-for-stable-dom" {
+ export var registerCommand: () => void;
+}


### PR DESCRIPTION
TypeScript can't properly parse this as a module, declaring the module and its exports explicitly fixes this issue.